### PR TITLE
Fix leftover page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Join Solid</title>
+    <title>Solid Hello World</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css">
     <link rel="manifest" href="manifest.json">
     <link rel="icon" href="images/favicon.png">


### PR DESCRIPTION
The `<title>` was `Join Solid`, a leftover from a different page — retitled to match this Hello World app. Visible on the browser tab / live demo.